### PR TITLE
Add cluster checking

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ sudo tail -F /var/log/syslog
 consul members  
 
 # Get list of members and their status (leader / follower)
-consul operator raft list-peers /
+consul operator raft list-peers 
 ```
 
 

--- a/test/integration/default/consul_test.rb
+++ b/test/integration/default/consul_test.rb
@@ -16,3 +16,14 @@ end
 describe command('sudo consul --version | grep Consul | cut -c 9-13') do
    its('stdout') { should match (/1.1.0/) }
 end
+
+# Check member status
+describe command('sudo consul members') do
+    its('exit_status') { should eq 0 }
+end
+
+# default-consul-0 should be the leader
+describe command('sudo consul operator raft list-peers | grep default-consul-0 | cut -c 74-79') do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should match (/leader/) }
+end


### PR DESCRIPTION
New tests verify that the cluster formed and that the leader is `default-consul-0`

resolves https://github.com/jsirianni/cookbook-consul/issues/5