### PR TITLE
Bind to a single address on version 1.2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@ https://www.consul.io/
 - Adding additional nodes should be automatic, a single chef role update and converge adds the nodes
 
 
+## Supported versions
+- Consul 1.2.1 on Ubuntu 16.04 LTS
+
+
 ## Usage
 ### Create a role for the cluster
 ```

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -31,7 +31,6 @@ default[:consul][:conf][:syslog]     = "true"
 default[:consul][:conf][:data_dir]   = "/opt/consul"
 default[:consul][:conf][:retry_join] = '["10.1.10.1"]'     # NOTE: Override w/ role # NOTE: Same as startjoin but will retry
 default[:consul][:conf][:bind_addr]  = '0.0.0.0' # Must be overridden if instance has multiple network interfaces
-default[:consul][:conf][:localhost]  = '127.0.0.1'
 
 
 # Systemd

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -31,6 +31,7 @@ default[:consul][:conf][:syslog]     = "true"
 default[:consul][:conf][:data_dir]   = "/opt/consul"
 default[:consul][:conf][:retry_join] = '["10.1.10.1"]'     # NOTE: Override w/ role # NOTE: Same as startjoin but will retry
 default[:consul][:conf][:bind_addr]  = '0.0.0.0' # Must be overridden if instance has multiple network interfaces
+default[:consul][:conf][:api_port]   = '8500' # default port
 
 
 # Systemd

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'joseph.sirianni88@gmail.com'
 license 'BSD 2-Clause License'
 description 'Installs/Configures a Consul cluster'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '0.1.4'
+version '0.1.5'
 chef_version '>= 12.14' if respond_to?(:chef_version)
 issues_url 'https://github.com/jsirianni/cookbook-consul/issues'
 source_url 'https://github.com/jsirianni/cookbook-consul'

--- a/templates/consul.service.erb
+++ b/templates/consul.service.erb
@@ -10,5 +10,5 @@ Group=<%=node[:consul][:group]%>
 Restart=on-failure
 ExecStart=<%=node[:consul][:binary]%> agent -server -bind <%=node[:consul][:conf][:bind_addr]%> -config-dir=<%=node[:consul][:conf][:base]%>
 
-ExecReload=<%=node[:consul][:binary]%> reload
+ExecReload=<%=node[:consul][:binary]%> reload -http-addr <%=node[:consul][:conf][:bind_addr]%>:<%=node[:consul][:conf][:api_port]%>
 KillSignal=SIGINT

--- a/templates/server.json.erb
+++ b/templates/server.json.erb
@@ -9,7 +9,6 @@
     "enable_syslog": <%=node[:consul][:conf][:syslog]%>,
     "retry_join" : <%=node[:consul][:conf][:retry_join]%>,
     "addresses": {
-        "http": "<%=node[:consul][:conf][:bind_addr]%>",
-        "http": "<%=node[:consul][:conf][:localhost]%>"
+        "http": "<%=node[:consul][:conf][:bind_addr]%>"
     }
 }

--- a/test/integration/default/consul_test.rb
+++ b/test/integration/default/consul_test.rb
@@ -1,3 +1,6 @@
+# Read node attributes
+node = json("/tmp/kitchen/dna.json").params
+
 # Archive should exist
 describe file('/tmp/consul.zip') do
     its('mode') { should cmp '0755' }
@@ -13,17 +16,17 @@ describe file('/usr/local/bin/consul') do
 end
 
 # Verify version 1.1.0
-describe command('sudo consul --version | grep Consul | cut -c 9-13') do
+describe command("sudo consul --version -http-addr #{node['consul']['conf']['bind_addr']}:8500 | grep Consul | cut -c 9-13") do
    its('stdout') { should match (/1.2.1/) }
 end
 
 # Check member status
-describe command('sudo consul members') do
+describe command("sudo consul members -http-addr #{node['consul']['conf']['bind_addr']}:8500") do
     its('exit_status') { should eq 0 }
 end
 
 # default-consul-0 should be the leader
-describe command('sudo consul operator raft list-peers | grep default-consul-0 | cut -c 74-79') do
+describe command("sudo consul operator raft list-peers -http-addr #{node['consul']['conf']['bind_addr']}:8500 | grep default-consul-0 | cut -c 74-79") do
     its('exit_status') { should eq 0 }
     its('stdout') { should match (/leader/) }
 end

--- a/test/integration/default/systemd_test.rb
+++ b/test/integration/default/systemd_test.rb
@@ -1,3 +1,6 @@
+# Read node attributes
+node = json("/tmp/kitchen/dna.json").params
+
 describe service "consul" do
     it { should be_installed }
     it { should be_enabled }
@@ -39,7 +42,7 @@ describe command('sudo cat /etc/systemd/system/consul.service | grep ExecStart |
 end
 
 describe command('sudo cat /etc/systemd/system/consul.service | grep ExecReload') do
-   its('stdout') { should match ("ExecReload=/usr/local/bin/consul reload") }
+   its('stdout') { should match ("ExecReload=/usr/local/bin/consul reload -http-addr #{node['consul']['conf']['bind_addr']}:8500") }
 end
 
 describe command('sudo cat /etc/systemd/system/consul.service | grep KillSignal') do


### PR DESCRIPTION
Ran into an issue where the web interface would only bind to a single address. Localhost was explicitly used in the past due to the consul cli using localhost (rather than the IP it is bound to). This does not seem to be an issue in 1.2.1. 

Tests and systemd commands now pass `-http-addr` to prevent consul client from targeting localhost.